### PR TITLE
exception for gates pillars

### DIFF
--- a/f1cloudwatch/init.sls
+++ b/f1cloudwatch/init.sls
@@ -22,6 +22,11 @@ logs:
       - {{ user }}
 {% endfor %}
 {% endif %}
+{% if pillar.siteusers is defined %}
+{% for user in pillar.siteusers %}
+      - {{ user }}
+{% endfor %}
+{% endif %}
 
 /var/log/{{ pillar.project }}/:
   file.directory:


### PR DESCRIPTION
Gates sites do not follow the standard vhosts.sls config and user "siteusers" insteads of vhosts or node.  Adding an exception to test for siteusers and then apply the logs group user add for that condition