### PR TITLE
Order last

### DIFF
--- a/f1cloudwatch/init.sls
+++ b/f1cloudwatch/init.sls
@@ -35,7 +35,7 @@ logs:
     - group: logs
     - makedirs: True
     - mode: 2774
-    - depends_on:
+    - require:
       - logs
       
 awslogs:

--- a/f1cloudwatch/init.sls
+++ b/f1cloudwatch/init.sls
@@ -27,6 +27,7 @@ logs:
       - {{ user }}
 {% endfor %}
 {% endif %}
+    - order: last
 
 /var/log/{{ pillar.project }}/:
   file.directory:


### PR DESCRIPTION
create the logs group and addusers as the last thing salt does.
This will make sure all the users are created before the state runs - which can cause an error
Also depends_On is not a salt requisite it is require