### PR TITLE
move to acl instead of groups

### DIFF
--- a/f1cloudwatch/init.sls
+++ b/f1cloudwatch/init.sls
@@ -1,33 +1,38 @@
 logs:
   group.present:
     - gid: 5647
+{% if salt['grains.get']('roles:web-server') is defined  %}
+php-logs:
+  group.present:
+    - name: logs
+    - gid: 5647
     - addusers:
-{% if pillar.vhosts is defined %}
+{% if pillar.vhosts is defined and pillar.vhosts.sites is defined  %}
 {% for site, name in pillar.vhosts.sites.items() %}
-  {% if name.user is defined %}
-  {% set user = name.user %}
-  {% else %}
-  {% set user = site %}
-  {% endif %}
-      - {{ user }}
-{% endfor %}
-{% endif %}
-{% if pillar.node is defined and pillar.node.sites is defined %}
-{% for site, name in pillar.node.sites.items() %}
-  {% if name.user is defined %}
-  {% set user = name.user %}
-  {% else %}
-  {% set user = site %}
-  {% endif %}
-      - {{ user }}
-{% endfor %}
-{% endif %}
-{% if pillar.siteusers is defined %}
-{% for user in pillar.siteusers %}
+  {% set user = name.user | default(site)%}
       - {{ user }}
 {% endfor %}
 {% endif %}
     - order: last
+{% endif %}
+
+{% if salt['grains.get']('roles:node-server') is defined  %}
+node-logs:
+  group.present:
+    - name: logs
+    - gid: 5647
+    - addusers:
+{% if pillar.node is defined and pillar.node.sites is defined %}
+{% for site, name in pillar.node.sites.items() %}
+  {% set user = name.user | default(site)%}
+      - {{ user }}
+  {% endfor %}
+{% elif pillar.siteusers is defined %}
+{% for user in pillar.siteusers %}
+      - {{ user }}
+{% endfor %}
+{% endif %}
+{% endif %}
 
 /var/log/{{ pillar.project }}/:
   file.directory:


### PR DESCRIPTION
This rework solves a few problems
1. checking etc password for the user - this resolves an error if the user does not exist on the system and the state errors. example PHP vs NODE hosts do not have the same set of users and this keeps us from having to evaluate based on grains that do not exist in all environments.
2. removing log groups and moving to ACL.  This should make things a little cleaner and resolve a dependency loop between the log group and the user existing before the state can run successfully.