### PR TITLE
rework amazon-linux-extras

### DIFF
--- a/f1cloudwatch/init.sls
+++ b/f1cloudwatch/init.sls
@@ -52,10 +52,16 @@ awslogs:
 /etc/awslogs/awslogs.conf:
   file.absent
 
-'amazon-linux-extras install -y collectd':
+'amazon-linux-extras enable collectd':
   cmd.run:
     - unless: 
-      - /bin/amazon-linux-extras list | grep collectd | grep -c enabled
+      - grep collectd /etc/yum.repos.d/amzn2-extras.repo
+
+install_collectd_aws_extras:
+  pkg.installed:
+    - fromrepo: amzn2extra-collectd
+    - pkgs:
+      - collectd
 
 install_cloudwatch_agent:
   pkg.installed:


### PR DESCRIPTION
This PR will address the issue of the 'amazon-linux-extras' command randomly hanging by:
1. only invoking the command to ENABLE the package in yum not INSTALL the package causing the command to only run if absolutely needed
2. installs the collectd package from amazon extras repo
